### PR TITLE
CardLayout support through seesaw.core/card-panel

### DIFF
--- a/src/seesaw/core.clj
+++ b/src/seesaw/core.clj
@@ -713,6 +713,32 @@
   (abstract-panel (BorderLayout.) border-layout-options opts))
 
 ;*******************************************************************************
+; Card
+
+(def ^{:private true} card-panel-options {
+  :items (fn [panel items]
+           (dorun (map (fn [[w id]] (.add panel (to-widget w) id)) items)))
+  :show #(.show (.getLayout %1) %1 %2)
+})
+
+(defn card-panel
+  "Create a panel with a card layout. Options:
+
+    :items A list of pairs with format [widget, identifier]
+           where identifier is a string.
+
+    :show  show a widget based on it's identifier. Only one
+           widget can be shown at a time.
+
+  See: 
+
+    http://download.oracle.com/javase/6/docs/api/java/awt/CardLayout.html
+  "
+  { :seesaw {:class 'javax.swing.JPanel }}
+  [& opts]
+  (abstract-panel (java.awt.CardLayout.) card-panel-options opts))
+
+;*******************************************************************************
 ; Flow
 
 (def ^{:private true} flow-align-table


### PR DESCRIPTION
A simple implementation of java.awt.CardLayout.
I don't know if you're going to like the :show parameter, it might not be 'seesawy' enough.
It would be nicer if it was possible to call `(show! panel identifier)`, but that isn't currently supported (and it would definitely be too big of a change). 
