### PR TITLE
Fix tiny bug in seesaw.test.examples.pi/calculate-pi-for.

### DIFF
--- a/test/seesaw/test/examples/pi.clj
+++ b/test/seesaw/test/examples/pi.clj
@@ -21,7 +21,7 @@
     (fn [acc i]
       (+ acc (/ (* 4.0 (- 1 (* (mod i 2) 2))) (+ (* 2 i) 1))))
     0.0
-    (range (* start step-size) (- (* (inc start) step-size) 1))))
+    (range (* start step-size) (* (inc start) step-size))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Agent Actions


### PR DESCRIPTION
Fix bug that the last element is not included to amount of pi calculation.
