### PR TITLE
JComboBox can now participate in seesaw bindings

### DIFF
--- a/src/seesaw/bind.clj
+++ b/src/seesaw/bind.clj
@@ -179,7 +179,7 @@
       (ssc/listen this :action
         (fn [e] (handler (.getSelectedItem this)))))
     (notify [this v] 
-      (when-not (= (int v) (.getSelectedItem this)) 
+      (when-not (= v (.getSelectedItem this)) 
         (.setSelectedItem this v))))
 
 (defn b-swap! 


### PR DESCRIPTION
I tried to add a JComboBox as the source of a binding, and seesaw started complaining about some missing code, so I added it. It's a very minor change. Let me know what you think.
