### PR TITLE
a fix for a tiny oversight in invoke/invoke-later doc string

### DIFF
--- a/src/seesaw/invoke.clj
+++ b/src/seesaw/invoke.clj
@@ -36,7 +36,7 @@
 
   Notes:
 
-    (seesaw.core/invoke-now) is an alias of this macro.
+    (seesaw.core/invoke-later) is an alias of this macro.
 
   See:
   


### PR DESCRIPTION
With this change invoke/invoke-later's docstring claims to be aliased by core/invoke-later instead of claiming to be aliased by _core/invoke-now_, which was clearly wrong.
