### PR TITLE
make full-screen! work on mac

### DIFF
--- a/src/seesaw/core.clj
+++ b/src/seesaw/core.clj
@@ -2673,7 +2673,18 @@
   "Make the given window/frame full-screen. Pass nil to return all windows
   to normal size."
   ([^java.awt.GraphicsDevice device window]
-    (.setFullScreenWindow device (to-root window))
+    (if window
+      (let [root (to-root window)]
+        (when (not= (.getFullScreenWindow device) root)
+          (.dispose root)
+          (.setUndecorated root true)
+          (.setFullScreenWindow device root)
+          (.show root)))
+      (when-let [root (.getFullScreenWindow device)]
+        (.dispose root)
+        (.setFullScreenWindow device nil)
+        (.setUndecorated root false)
+        (.show root)))
     window)
   ([window]
     (full-screen! (default-screen-device) window)))


### PR DESCRIPTION
Hi Dave,

I found I needed to add this code to make seesaw.core/full-screen! work properly on the mac. I believe this should also work fine on Windows.

Arthur
