### PR TITLE
Use j18n v1.0.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [com.miglayout/miglayout "3.7.4"]
                  [com.jgoodies/forms "1.2.1"]
                  [org.swinglabs.swingx/swingx-core "1.6.3"]
-                 [j18n "1.0.0"]
+                 [j18n "1.0.1"]
                  [org.fife.ui/rsyntaxtextarea "2.0.3"]]
   :dev-dependencies [[com.stuartsierra/lazytest "1.1.2"]
                      [lein-clojars "0.7.0"]


### PR DESCRIPTION
Please use j18n 1.0.1. I fixed a mistake in the pom. Otherwise it's identical.
