### PR TITLE
Documentation on how to run examples was out of date

### DIFF
--- a/test/seesaw/test/examples/README.txt
+++ b/test/seesaw/test/examples/README.txt
@@ -3,6 +3,6 @@ capability of the API. Each has a -main function so they can be run
 individually with "lein run -m". There's also a gui launcher from which they
 can be started more quickly:
 
-  $ lein run :examples
+  $ lein examples
 
 When the launcher ui pops up, just double-click entries to run them.


### PR DESCRIPTION
This edit fixes out of date documentation.
