### PR TITLE
Support for multiple frame icons

### DIFF
--- a/src/seesaw/core.clj
+++ b/src/seesaw/core.clj
@@ -2793,7 +2793,17 @@
 
       (bean-option :undecorated? java.awt.Frame boolean)
 
-      (bean-option [:icon :icon-image] javax.swing.JFrame frame-icon-converter))))
+      (bean-option
+        [:icon :icon-image]
+        javax.swing.JFrame
+        frame-icon-converter nil
+        "The image to be displayed as the icon for this frame")
+
+      (bean-option
+        [:icons :icon-images]
+        java.awt.Window
+        (partial map frame-icon-converter) nil
+        "Sequence of images to be displayed as the icon for this frame"))))
 
 (option-provider javax.swing.JFrame frame-options)
 


### PR DESCRIPTION
This adds support for an `:icons` property in frames so that icons in different sizes can be specified for different purposes (window decoration,task bar...). This makes uses of the `setImagesIcons` method defined in `java.awt.Window`. Additionally, this commit adds a docstring to the existing `:icon` property.
