### PR TITLE
parent option is not passed to custom-dialog when using dialog

### DIFF
--- a/src/seesaw/core.clj
+++ b/src/seesaw/core.clj
@@ -3155,7 +3155,6 @@
 })
 
 (def ^:private dialog-defaults {
-  :parent         nil
   :content        "Please set the :content option."
   :option-type    :default
   :type           :plain


### PR DESCRIPTION
When using the dialog funciton to create a dialog, the :parent option is ignored and not passed to custom-dialog, so that the position of the displayed dialog does not take the position of the parent frame into account. The attached commit fixes this behaviour.
