### PR TITLE
Ref bind

### DIFF
--- a/src/seesaw/bind.clj
+++ b/src/seesaw/bind.clj
@@ -148,6 +148,15 @@
         (fn [] (remove-watch this key))))
     (notify [this v] (throw (IllegalStateException. "Can't notify an agent!")))
 
+  clojure.lang.Ref
+  (subscribe [this handler]
+    (let [key (keyword (gensym "bindable-ref-watcher"))]
+      (add-watch this key
+                 (fn bindable-ref-watcher
+                   [k r o n] (when-not (= o n) (handler n))))
+      (fn [] (remove-watch this key))))
+  (notify [this v] (dosync (ref-set this v)))
+
   javax.swing.text.Document
     (subscribe [this handler]
       (ssc/listen this :document

--- a/test/seesaw/test/bind.clj
+++ b/test/seesaw/test/bind.clj
@@ -172,7 +172,24 @@
                     true)
                   ; Unfortunately, in Clojure 1.2, IllegalStateException gets wrapped by reset!
                   (catch RuntimeException e
-                    (= IllegalStateException (class (.getCause e))))))))))
+                    (= IllegalStateException (class (.getCause e)))))))))
+
+  (testing "given a Ref"
+    (it "should pass along changes to the ref's value"
+      (let [start (ref nil)
+            end   (atom nil)]
+        (bind start end)
+        (dosync
+         (alter start (constantly "foo")))
+        (expect (= "foo" @start))
+        (expect (= "foo" @end))))
+    (it "should pass update the ref's value when the source changes"
+      (let [start (atom nil)
+            end   (ref nil)]
+        (bind start end)
+        (reset! start "foo")
+        (expect (= "foo" @start))
+        (expect (= "foo" @end)))))        )
 
 (describe b-do*
   (it "executes a function with a single argument and ends a chain"


### PR DESCRIPTION
This adds Refs to the Bindable protocol with an implementation modeled after Atoms.  Thus, Refs will be similar to Atoms when binding.  There is not special treatment of their transactional semantics when applied to an ensemble of Refs.

The test is very basic and just tests whether value propagation works from Ref to Atom and from Atom to Ref.
