### PR TITLE
seesaw.clipboard/contents! should keep a owner data when argument are a string and a owner

### DIFF
--- a/src/seesaw/clipboard.clj
+++ b/src/seesaw/clipboard.clj
@@ -37,7 +37,7 @@
    (let [cb (system)]
      (cond
        (string? transferable)
-         (contents! (dnd/default-transferable [dnd/string-flavor transferable]))
+         (contents! (dnd/default-transferable [dnd/string-flavor transferable]) owner)
      :else
        (.setContents (system) ^java.awt.datatransfer.Transferable transferable owner))
      cb)))


### PR DESCRIPTION
When clipboard/contents! called with a string and a clipboard owner, it called itself with only the string transferable. The owner is missing. 
