### PR TITLE
Added optional constructor arguments to 'construct' and made 'base-resource-options' public.

### DIFF
--- a/src/seesaw/core.clj
+++ b/src/seesaw/core.clj
@@ -216,8 +216,8 @@
   A macro that returns a proxied instance of the given class. This is
   used by Seesaw to construct widgets that can be fiddled with later,
   e.g. installing a paint handler, etc."
-  ([factory-class]
-    `(proxy [~factory-class seesaw.selector.Tag] []
+  ([factory-class & opts]
+    `(proxy [~factory-class seesaw.selector.Tag] [~@opts]
        (tag_name [] (.getSimpleName ~factory-class)))))
 
 
@@ -813,7 +813,7 @@
 (def ^{:private true} boolean-examples 'boolean)
 (def ^{:private true} dimension-examples [[640 :by 480] 'java.awt.Dimension])
 
-(def ^{:private true} base-resource-options [:text :foreground :background :font :icon :tip])
+(def base-resource-options [:text :foreground :background :font :icon :tip])
 
 (def default-options
   (option-map


### PR DESCRIPTION
This resolves #172. The motivation behind the changes is to be able to write libraries which use the seesaw facilities to provide more components. Especially components which are not likely to be included in future versions of seesaw. Consider a possible extension my-custom-lib.core containing code for a seesaw-ish JMyCustomComponent wrapper:

``` clojure
(def my-custom-component-options
  (merge
    default-options
    (option-map
      (resource-option :resource base-resource-options)
      ...)))

(widget-option-provider JMyCustomComponent my-custom-component-options)

(defn my-custom-component
  "TODO"
  [& opts]
  (apply-options
    (construct JMyCustomComponent ...)))
```

The need for making base-resource-options public is self-explanatory. The addition of optional parameters to construct is driven by the fact that some components do not have no argument constructors.
