### PR TITLE
Anti-aliasing is a 30x performance hit for me.

### DIFF
--- a/src/seesaw/core.clj
+++ b/src/seesaw/core.clj
@@ -2506,7 +2506,7 @@
 
 (defn- paint-component-impl [^javax.swing.JComponent this ^java.awt.Graphics2D g]
   (let [{:keys [before after super? anti-alias?] :or {super? true anti-alias? true}} (get-meta this paint-property)]
-    (when anti-alias? (seesaw.graphics/anti-alias g)
+    (when anti-alias? (seesaw.graphics/anti-alias g))
     (when before (seesaw.graphics/push g (before this g)))
     ; TODO reflection here can't be eliminated thanks for proxy limitations
     ; with protected methods

--- a/src/seesaw/core.clj
+++ b/src/seesaw/core.clj
@@ -2505,8 +2505,8 @@
 (def ^{:private true} paint-property "seesaw-paint")
 
 (defn- paint-component-impl [^javax.swing.JComponent this ^java.awt.Graphics2D g]
-  (let [{:keys [before after super?] :or {super? true}} (get-meta this paint-property)]
-    (seesaw.graphics/anti-alias g)
+  (let [{:keys [before after super? anti-alias?] :or {super? true anti-alias? true}} (get-meta this paint-property)]
+    (when anti-alias? (seesaw.graphics/anti-alias g)
     (when before (seesaw.graphics/push g (before this g)))
     ; TODO reflection here can't be eliminated thanks for proxy limitations
     ; with protected methods


### PR DESCRIPTION
I'm not sure if anti-aliasing should be on by default given the drastic performance hit. Should it be optional to turn it off? Or off by default?
