### PR TITLE
Fix bug where long is put into spinner model that is holding ints.

### DIFF
--- a/src/seesaw/core.clj
+++ b/src/seesaw/core.clj
@@ -1906,7 +1906,10 @@
   [v & {:keys [from to by]}]
   (cond
     ; TODO Reflection here. Don't know how to get rid of it.
-    (number? v) (javax.swing.SpinnerNumberModel. v from to (or by 1))
+    (number? v) 
+    (let [step (or by 1)] 
+      (javax.swing.SpinnerNumberModel. ^Number v ^Comparable from ^Comparable to 
+                                       ^Number step))
     (instance? java.util.Date v)
       (javax.swing.SpinnerDateModel. ^java.util.Date v
                                      from to


### PR DESCRIPTION
This bug was caused by the ambiguity of the SpinnerNumberModel constructor. Clojure coerces longs to ints to match the interger form of the constructor (but not always?). If we set the spinner value to a long, we set up a potential error when we try to fetch the previous or next values. This PR ensures that calls to selection! on jspinner will set as Integer if the SpinnerNumberModel is of that type. see fixes #181