### PR TITLE
Documented :all-files? option of choose-file and made the first filter to be preselected. 

### DIFF
--- a/src/seesaw/chooser.clj
+++ b/src/seesaw/chooser.clj
@@ -152,8 +152,8 @@
     ; ask & return single file
     (choose-file)
 
-    ; ask & return including a filter for image files and an "all files" filter
-    ; appearing at the beginning
+    ; ask & return including a filter for image files and an \"all files\"
+    ; filter appearing at the beginning
     (choose-file :all-files? false
                  :filters [(file-filter \"All files\" (constantly true))
                            [\"Images\" [\"png\" \"jpeg\"]]


### PR DESCRIPTION
I noticed :all-files? was undocumented so I quickly fixed that. I also added functionality to preselect the first filter in the filter list which was not the case; the user had to manually select an option. Last, I fixed the source code for the last example and changed it a bit.
