### PR TITLE
Allow setting `false` boolean values via update-at!

### DIFF
--- a/src/seesaw/table.clj
+++ b/src/seesaw/table.clj
@@ -229,8 +229,9 @@
           ^objects row-values  (unpack-row col-key-map value)]
       (doseq [i (range 0 (.getColumnCount target))]
         ; TODO this precludes setting a cell to nil. Do we care?
-        (when-let [v (aget row-values i)]
-          (.setValueAt target (aget row-values i) row i)))
+        (let [v (aget row-values i)]
+          (when-not (nil? v)
+            (.setValueAt target (aget row-values i) row i))))
       ; merge with current full-map value so that extra fields aren't lost.
       (.setValueAt target
                    (merge (.getValueAt target row -1)

--- a/test/seesaw/test/table.clj
+++ b/test/seesaw/test/table.clj
@@ -123,7 +123,14 @@
           r (update-at! t 1 ["A1" "B1"] 0 {:a "A0" :b "B0"})]
       (expect (= t r))
       (expect (= {:a "A0" :b "B0"} (value-at t 0)))
-      (expect (= {:a "A1" :b "B1"} (value-at t 1))))))
+      (expect (= {:a "A1" :b "B1"} (value-at t 1)))))
+  (it "supports `false` boolean values"
+    (let [t (table-model :columns [{:class java.lang.Boolean :key :a}]
+                         :rows [[false] [true]])
+          r (update-at! t 0 [true] 1 [false])]
+      (expect (= t r))
+      (expect (= {:a true} (value-at t 0)))
+      (expect (= {:a false} (value-at t 1))))))
 
 (describe insert-at!
   (it "inserts a row with the same format as :rows option of (table-model)"


### PR DESCRIPTION
I'm using Boolean columns in a project and need to be able to use `update-at!` with a false boolean value. This commit allows that, and includes a test that demonstrated the problem.