### PR TITLE
Fix default timer delay of 0ms

### DIFF
--- a/src/seesaw/timer.clj
+++ b/src/seesaw/timer.clj
@@ -43,6 +43,7 @@
   [f & {:keys [start? initial-value] :or {start? true} :as opts}]
   (let [a (action :handler (timer-handler f initial-value))
         t (javax.swing.Timer. 0 a)]
+    (.setDelay t 1000)
     (apply-options t (dissoc opts :start? :initial-value))
     (when start? (.start t))
     t))


### PR DESCRIPTION
Timer now has delay set to 1000ms by default.
The default 1000ms delay does not apply to the initial delay, which is initialized to 0ms.
Problem initially identified in issue #192.