### PR TITLE
Exclude boolean?

### DIFF
--- a/src/seesaw/util.clj
+++ b/src/seesaw/util.clj
@@ -9,6 +9,7 @@
 ;   You must not remove this notice, or any other, from this software.
 
 (ns seesaw.util
+  (:refer-clojure :exclude [boolean?])
   (:require clojure.string
             [j18n.core :as j18n])
   (:import [java.net URL URI MalformedURLException URISyntaxException]))


### PR DESCRIPTION
Using seesaw throws the following error for me:
WARNING: boolean? already refers to: #'clojure.core/boolean? in namespace: seesaw.util, being replaced by: #'seesaw.util/boolean?

I fixed that by excluding clojure core's boolean? in that namespace.