### PR TITLE
typo in seesaw/table.clj documentation

### DIFF
--- a/src/seesaw/table.clj
+++ b/src/seesaw/table.clj
@@ -187,7 +187,7 @@
     ; Print values of selected rows
     (listen t :selection
       (fn [e]
-        (println (value-at t (selection {:multi? true} t)))))
+        (println (value-at t (selection t {:multi? true})))))
   See:
     (seesaw.core/table)
     (seesaw.table/table-model)


### PR DESCRIPTION
very small typo, but it tripped me up and caused a digression in to the javadocs