### PR TITLE
fix java method name when call quad-to within path expr

### DIFF
--- a/src/seesaw/graphics.clj
+++ b/src/seesaw/graphics.clj
@@ -141,7 +141,7 @@
   'line-to '.lineTo
   'move-to '.moveTo
   'curve-to '.curveTo
-  'quad-to 'quad-to
+  'quad-to '.quadTo
 })
 
 (defmacro path [opts & forms]


### PR DESCRIPTION
There is a typo error in graphics.clj:

```clojure
(def ^{:private true} path-ops {
  'line-to '.lineTo
  'move-to '.moveTo
  'curve-to '.curveTo
  'quad-to 'quad-to 
})
```

_quad-to_ should mapped to _'.quadTo_ .